### PR TITLE
Simplify Glaze meta and avoid potential buffer copies

### DIFF
--- a/src/ThirdParty/Glaze_Common.h
+++ b/src/ThirdParty/Glaze_Common.h
@@ -1,283 +1,279 @@
 #ifndef GLAZE_COMMON_H
 #define GLAZE_COMMON_H
 
-#include "test.h"
-#include "TypeSafe.h"
 #include "JsonifierCatalog.h"
 #include "JsonifierCountry.h"
 #include "JsonifierTwitter.h"
+#include "TypeSafe.h"
 #include "glaze/glaze.hpp"
+#include "test.h"
 
-template<> struct glz::meta<geometry_data> {
-	using value_type = geometry_data;
-	static constexpr auto value = object("coordinates", &value_type::coordinates, "type", &value_type::type);
+template <> struct glz::meta<geometry_data> {
+  using T = geometry_data;
+  static constexpr auto value = object(&T::coordinates, &T::type);
 };
 
-template<> struct glz::meta<properties_data> {
-	using value_type = properties_data;
-	static constexpr auto value = object("name", &value_type::name);
+template <> struct glz::meta<properties_data> {
+  using T = properties_data;
+  static constexpr auto value = object(&T::name);
 };
 
-template<> struct glz::meta<feature> {
-	using value_type = feature;
-	static constexpr auto value = object("properties", &value_type::properties, "geometry", &value_type::geometry, "type", &value_type::type);
+template <> struct glz::meta<feature> {
+  using T = feature;
+  static constexpr auto value = object(&T::properties, &T::geometry, &T::type);
 };
 
-template<> struct glz::meta<canada_message> {
-	using value_type = canada_message;
-	static constexpr auto value = object("features", &value_type::features, "type", &value_type::type);
+template <> struct glz::meta<canada_message> {
+  using T = canada_message;
+  static constexpr auto value = object(&T::features, &T::type);
 };
 
-template<> struct glz::meta<search_metadata_data> {
-	using value_type = search_metadata_data;
-	static constexpr auto value =
-		object("since_id_str", &value_type::since_id_str, "next_results", &value_type::next_results, "refresh_url", &value_type::refresh_url, "max_id_str", &value_type::max_id_str,
-			"completed_in", &value_type::completed_in, "query", &value_type::query, "since_id", &value_type::since_id, "count", &value_type::count, "max_id", &value_type::max_id);
+template <> struct glz::meta<search_metadata_data> {
+  using T = search_metadata_data;
+  static constexpr auto value = object(
+      &T::since_id_str, &T::next_results, &T::refresh_url, &T::max_id_str,
+      &T::completed_in, &T::query, &T::since_id, &T::count, &T::max_id);
 };
 
-template<> struct glz::meta<hashtag_data> {
-	using value_type = hashtag_data;
-	static constexpr auto value = object("indices", &value_type::indices, "text", &value_type::text);
+template <> struct glz::meta<hashtag_data> {
+  using T = hashtag_data;
+  static constexpr auto value = object(&T::indices, &T::text);
 };
 
-template<> struct glz::meta<large_data> {
-	using value_type = large_data;
-	static constexpr auto value = object("resize", &value_type::resize, "w", &value_type::w, "h", &value_type::h);
+template <> struct glz::meta<large_data> {
+  using T = large_data;
+  static constexpr auto value = object(&T::resize, &T::w, &T::h);
 };
 
-template<> struct glz::meta<sizes_data> {
-	using value_type = sizes_data;
-	static constexpr auto value = object("medium", &value_type::medium, "small", &value_type::small, "thumb", &value_type::thumb, "large", &value_type::large);
+template <> struct glz::meta<sizes_data> {
+  using T = sizes_data;
+  static constexpr auto value =
+      object(&T::medium, &T::small, &T::thumb, &T::large);
 };
 
-template<> struct glz::meta<media_data> {
-	using value_type = media_data;
-	static constexpr auto value = object("source_status_id_str", &value_type::source_status_id_str, "source_status_id", &value_type::source_status_id, "indices",
-		&value_type::indices, "media_url_https", &value_type::media_url_https, "expanded_url", &value_type::expanded_url, "display_url", &value_type::display_url, "media_url",
-		&value_type::media_url, "id_str", &value_type::id_str, "type", &value_type::type, "sizes", &value_type::sizes, "url", &value_type::url, "id", &value_type::id);
+template <> struct glz::meta<media_data> {
+  using T = media_data;
+  static constexpr auto value =
+      object(&T::source_status_id_str, &T::source_status_id, &T::indices,
+             &T::media_url_https, &T::expanded_url, &T::display_url,
+             &T::media_url, &T::id_str, &T::type, &T::sizes, &T::url, &T::id);
 };
 
-template<> struct glz::meta<url_data> {
-	using value_type = url_data;
-	static constexpr auto value =
-		object("indices", &value_type::indices, "expanded_url", &value_type::expanded_url, "display_url", &value_type::display_url, "url", &value_type::url);
+template <> struct glz::meta<url_data> {
+  using T = url_data;
+  static constexpr auto value =
+      object(&T::indices, &T::expanded_url, &T::display_url, &T::url);
 };
 
-template<> struct glz::meta<user_mention> {
-	using value_type = user_mention;
-	static constexpr auto value =
-		object("indices", &value_type::indices, "screen_name", &value_type::screen_name, "id_str", &value_type::id_str, "name", &value_type::name, "id", &value_type::id);
+template <> struct glz::meta<user_mention> {
+  using T = user_mention;
+  static constexpr auto value =
+      object(&T::indices, &T::screen_name, &T::id_str, &T::name, &T::id);
 };
 
-template<> struct glz::meta<status_entities> {
-	using value_type = status_entities;
-	static constexpr auto value = object("media", &value_type::media, "user_mentions", &value_type::user_mentions, "symbols", &value_type::symbols, "hashtags",
-		&value_type::hashtags, "urls", &value_type::urls);
+template <> struct glz::meta<status_entities> {
+  using T = status_entities;
+  static constexpr auto value =
+      object(&T::media, &T::user_mentions, &T::symbols, &T::hashtags, &T::urls);
 };
 
-template<> struct glz::meta<metadata_data> {
-	using value_type = metadata_data;
-	static constexpr auto value = object("iso_language_code", &value_type::iso_language_code, "result_type", &value_type::result_type);
+template <> struct glz::meta<metadata_data> {
+  using T = metadata_data;
+  static constexpr auto value = object(&T::iso_language_code, &T::result_type);
 };
 
-template<> struct glz::meta<description_data> {
-	using value_type = description_data;
-	static constexpr auto value = object("urls", &value_type::urls);
+template <> struct glz::meta<description_data> {
+  using T = description_data;
+  static constexpr auto value = object(&T::urls);
 };
 
-template<> struct glz::meta<user_entities> {
-	using value_type = user_entities;
-	static constexpr auto value = object("url", &value_type::url, "description", &value_type::description);
+template <> struct glz::meta<user_entities> {
+  using T = user_entities;
+  static constexpr auto value = object(&T::url, &T::description);
 };
 
-template<> struct glz::meta<twitter_user_data> {
-	using value_type = twitter_user_data;
-	static constexpr auto value = object("profile_background_image_url_https", &value_type::profile_background_image_url_https, "profile_banner_url",
-		&value_type::profile_banner_url, "profile_background_image_url", &value_type::profile_background_image_url, "profile_sidebar_border_color",
-		&value_type::profile_sidebar_border_color, "profile_sidebar_fill_color", &value_type::profile_sidebar_fill_color, "time_zone", &value_type::time_zone,
-		"profile_background_color", &value_type::profile_background_color, "profile_image_url_https", &value_type::profile_image_url_https, "utc_offset", &value_type::utc_offset,
-		"profile_use_background_image", &value_type::profile_use_background_image, "url", &value_type::url, "profile_text_color", &value_type::profile_text_color,
-		"profile_link_color", &value_type::profile_link_color, "profile_image_url", &value_type::profile_image_url, "profile_background_tile", &value_type::profile_background_tile,
-		"is_translation_enabled", &value_type::is_translation_enabled, "default_profile_image", &value_type::default_profile_image, "contributors_enabled",
-		&value_type::contributors_enabled, "follow_request_sent", &value_type::follow_request_sent, "favourites_count", &value_type::favourites_count, "description",
-		&value_type::description, "screen_name", &value_type::screen_name, "followers_count", &value_type::followers_count, "statuses_count", &value_type::statuses_count,
-		"created_at", &value_type::created_at, "entities", &value_type::entities, "friends_count", &value_type::friends_count, "default_profile", &value_type::default_profile,
-		"listed_count", &value_type::listed_count, "location", &value_type::location, "protected", &value_type::protectedVal, "is_translator", &value_type::is_translator, "id_str",
-		&value_type::id_str, "notifications", &value_type::notifications, "name", &value_type::name, "geo_enabled", &value_type::geo_enabled, "lang", &value_type::lang,
-		"following", &value_type::following, "verified", &value_type::verified, "id", &value_type::id);
+template <> struct glz::meta<twitter_user_data> {
+  using T = twitter_user_data;
+  static constexpr auto value = object(
+      &T::profile_background_image_url_https, &T::profile_banner_url,
+      &T::profile_background_image_url, &T::profile_sidebar_border_color,
+      &T::profile_sidebar_fill_color, &T::time_zone,
+      &T::profile_background_color, &T::profile_image_url_https, &T::utc_offset,
+      &T::profile_use_background_image, &T::url, &T::profile_text_color,
+      &T::profile_link_color, &T::profile_image_url,
+      &T::profile_background_tile, &T::is_translation_enabled,
+      &T::default_profile_image, &T::contributors_enabled,
+      &T::follow_request_sent, &T::favourites_count, &T::description,
+      &T::screen_name, &T::followers_count, &T::statuses_count, &T::created_at,
+      &T::entities, &T::friends_count, &T::default_profile, &T::listed_count,
+      &T::location, "protected", &T::protectedVal, &T::is_translator,
+      &T::id_str, &T::notifications, &T::name, &T::geo_enabled, &T::lang,
+      &T::following, &T::verified, &T::id);
 };
 
-template<> struct glz::meta<status_data> {
-	using value_type = status_data;
-	static constexpr auto value = object("in_reply_to_status_id_str", &value_type::in_reply_to_status_id_str, "in_reply_to_user_id_str", &value_type::in_reply_to_user_id_str,
-		"in_reply_to_screen_name", &value_type::in_reply_to_screen_name, "in_reply_to_status_id", &value_type::in_reply_to_status_id, "in_reply_to_user_id",
-		&value_type::in_reply_to_user_id, "possibly_sensitive", &value_type::possibly_sensitive, "contributors", &value_type::contributors, "coordinates", &value_type::coordinates,
-		"place", &value_type::place, "geo", &value_type::geo, "entities", &value_type::entities, "favorite_count", &value_type::favorite_count, "metadata", &value_type::metadata,
-		"created_at", &value_type::created_at, "retweeted_status", &value_type::retweeted_status, "retweet_count", &value_type::retweet_count, "source", &value_type::source,
-		"id_str", &value_type::id_str, "user", &value_type::user, "lang", &value_type::lang, "text", &value_type::text, "truncated", &value_type::truncated, "favorited",
-		&value_type::favorited, "retweeted", &value_type::retweeted, "id", &value_type::id);
+template <> struct glz::meta<status_data> {
+  using T = status_data;
+  static constexpr auto value = object(
+      &T::in_reply_to_status_id_str, &T::in_reply_to_user_id_str,
+      &T::in_reply_to_screen_name, &T::in_reply_to_status_id,
+      &T::in_reply_to_user_id, &T::possibly_sensitive, &T::contributors,
+      &T::coordinates, &T::place, &T::geo, &T::entities, &T::favorite_count,
+      &T::metadata, &T::created_at, &T::retweeted_status, &T::retweet_count,
+      &T::source, &T::id_str, &T::user, &T::lang, &T::text, &T::truncated,
+      &T::favorited, &T::retweeted, &T::id);
 };
 
-template<> struct glz::meta<twitter_message> {
-	using value_type = twitter_message;
-	static constexpr auto value = object("search_metadata", &value_type::search_metadata, "statuses", &value_type::statuses);
+template <> struct glz::meta<twitter_message> {
+  using T = twitter_message;
+  static constexpr auto value = object(&T::search_metadata, &T::statuses);
 };
 
-
-template<> struct glz::meta<audience_sub_category_names> {
-	using value_type = audience_sub_category_names;
-	static constexpr auto value = object("337100890", &value_type::the337100890);
+template <> struct glz::meta<audience_sub_category_names> {
+  using T = audience_sub_category_names;
+  static constexpr auto value = object("337100890", &T::the337100890);
 };
 
-template<> struct glz::meta<names> {
-	using value_type = names;
-	static constexpr auto value = object();
+template <> struct glz::meta<names> {
+  using T = names;
+  static constexpr auto value = object();
 };
 
-template<> struct glz::meta<event> {
-	using value_type = event;
-	static constexpr auto value = object("description", &value_type::description, "subTopicIds", &value_type::subTopicIds, "logo", &value_type::logo, "topicIds",
-		&value_type::topicIds, "subjectCode", &value_type::subjectCode, "subtitle", &value_type::subtitle, "name", &value_type::name, "id", &value_type::id);
+template <> struct glz::meta<event> {
+  using T = event;
+  static constexpr auto value =
+      object(&T::description, &T::subTopicIds, &T::logo, &T::topicIds,
+             &T::subjectCode, &T::subtitle, &T::name, &T::id);
 };
 
-template<> struct glz::meta<price> {
-	using value_type = price;
-	static constexpr auto value = object("audienceSubCategoryId", &value_type::audienceSubCategoryId, "seatCategoryId", &value_type::seatCategoryId, "amount", &value_type::amount);
+template <> struct glz::meta<price> {
+  using T = price;
+  static constexpr auto value =
+      object(&T::audienceSubCategoryId, &T::seatCategoryId, &T::amount);
 };
 
-template<> struct glz::meta<area> {
-	using value_type = area;
-	static constexpr auto value = object("blockIds", &value_type::blockIds, "areaId", &value_type::areaId);
+template <> struct glz::meta<area> {
+  using T = area;
+  static constexpr auto value = object(&T::blockIds, &T::areaId);
 };
 
-template<> struct glz::meta<seat_category> {
-	using value_type = seat_category;
-	static constexpr auto value = object("areas", &value_type::areas, "seatCategoryId", &value_type::seatCategoryId);
+template <> struct glz::meta<seat_category> {
+  using T = seat_category;
+  static constexpr auto value = object(&T::areas, &T::seatCategoryId);
 };
 
-template<> struct glz::meta<performance> {
-	using value_type = performance;
-	static constexpr auto value = object("seatCategories", &value_type::seatCategories, "logo", &value_type::logo, "seatMapImage", &value_type::seatMapImage, "prices",
-		&value_type::prices, "venueCode", &value_type::venueCode, "name", &value_type::name, "eventId", &value_type::eventId, "start", &value_type::start, "id", &value_type::id);
+template <> struct glz::meta<performance> {
+  using T = performance;
+  static constexpr auto value =
+      object(&T::seatCategories, &T::logo, &T::seatMapImage, &T::prices,
+             &T::venueCode, &T::name, &T::eventId, &T::start, &T::id);
 };
 
-template<> struct glz::meta<venue_names> {
-	using value_type = venue_names;
-	static constexpr auto value = object("PLEYEL_PLEYEL", &value_type::PLEYEL_PLEYEL);
+template <> struct glz::meta<venue_names> {
+  using T = venue_names;
+  static constexpr auto value = object("PLEYEL_PLEYEL", &T::PLEYEL_PLEYEL);
 };
 
-template<> struct glz::meta<citm_catalog_message> {
-	using value_type = citm_catalog_message;
-	static constexpr auto value = object("audienceSubCategoryNames", &value_type::audienceSubCategoryNames, "topicSubTopics", &value_type::topicSubTopics, "seatCategoryNames",
-		&value_type::seatCategoryNames, "subTopicNames", &value_type::subTopicNames, "areaNames", &value_type::areaNames, "topicNames", &value_type::topicNames, "performances",
-		&value_type::performances, "events", &value_type::events, "venueNames", &value_type::venueNames, "subjectNames", &value_type::subjectNames, "blockNames",
-		&value_type::blockNames);
+template <> struct glz::meta<citm_catalog_message> {
+  using T = citm_catalog_message;
+  static constexpr auto value = object(
+      &T::audienceSubCategoryNames, &T::topicSubTopics, &T::seatCategoryNames,
+      &T::subTopicNames, &T::areaNames, &T::topicNames, &T::performances,
+      &T::events, &T::venueNames, &T::subjectNames, &T::blockNames);
 };
 
-template<> struct glz::meta<Obj3> {
-	using value_type = Obj3;
-	static constexpr auto value = object(
-		"a", &value_type::a,
-		"foo", &value_type::foo
-	);
+template <> struct glz::meta<Obj3> {
+  using T = Obj3;
+  static constexpr auto value = object(&T::a, &T::foo);
 };
 
-template<> struct glz::meta<Obj2> {
-	using value_type = Obj2;
-	static constexpr auto value = object(
-		"foo", &value_type::foo
-	);
+template <> struct glz::meta<Obj2> {
+  using T = Obj2;
+  static constexpr auto value = object(&T::foo);
 };
 
-namespace Glaze
-{
+namespace Glaze {
 
-	class VectorDouble : public TestAction
-	{
-	public:
-		virtual bool ParseDouble(const char* json, long double& reply) const
-		{
-			auto result = glz::read_json<std::vector<double>>(json);
-			if (result) {
-				std::vector<double> data;
-				data = std::move(result.value());
-				if (data.size() == 1) {
-					reply = data[0];
-				}
-			}
-			return true;
-		}
-	};
-
-	class VectorString : public TestAction
-	{
-	public:
-		virtual bool ParseString(const char* json, std::string& reply) const
-		{
-			auto result = glz::read_json<std::vector<std::string>>(json);
-			if (result) {
-				std::vector<std::string> data;
-				data = std::move(result.value());
-				if (data.size() == 1) {
-					reply = data[0];
-				}
-			}
-			return true;
-		}
-	};
-
-
-	template<typename T>
-	struct GetValueResult : public ParseResultBase
-	{
-		T       data;
-	};
-}
-
-
-template<typename T> struct glz::meta<Glaze::GetValueResult<T>> {
-	using value_type = Glaze::GetValueResult<T>;
-	static constexpr auto value =
-		object(&value_type::data);
+class VectorDouble : public TestAction {
+public:
+  virtual bool ParseDouble(const char *json, long double &reply) const {
+    std::vector<double> data;
+    auto ec = glz::read_json(data, json);
+    if (not ec) {
+      if (data.size() == 1) {
+        reply = data[0];
+      }
+    }
+    return true;
+  }
 };
 
+class VectorString : public TestAction {
+public:
+  virtual bool ParseString(const char *json, std::string &reply) const {
+    std::vector<std::string> data;
+    auto ec = glz::read_json(data, json);
+    if (not ec) {
+      if (data.size() == 1) {
+        reply = data[0];
+      }
+    }
+    return true;
+  }
+};
 
-namespace Glaze
-{
+template <typename T> struct GetValueResult : public ParseResultBase {
+  T data;
+};
+} // namespace Glaze
 
-	template<typename T>
-	class GetValue : public TestAction
-	{
+template <typename T> struct glz::meta<Glaze::GetValueResult<T>> {
+  using T = Glaze::GetValueResult<T>;
+  static constexpr auto value = object(&T::data);
+};
 
-	public:
-		virtual bool Parse(const char* json, size_t, std::unique_ptr<ParseResultBase>& reply) const
-		{
-			std::unique_ptr<GetValueResult<T>>    parsedData = std::make_unique<GetValueResult<T>>();
-			auto error = glz::read < glz::opts{ .validate_trailing_whitespace = true } > (parsedData->data, json);
-			if (!error) {
-				reply = std::move(parsedData);
-			}
-			return true;
-		}
-		virtual bool Stringify(const ParseResultBase& parsedData, std::unique_ptr<StringResultBase>& reply)  const
-		{
-			GetValueResult<T> const& parsedDataInput = dynamic_cast<GetValueResult<T> const&>(parsedData);
-			std::unique_ptr<StringResultUsingString>    output = std::make_unique<StringResultUsingString>();
+namespace Glaze {
 
-			output->result = glz::write_json(parsedDataInput.data).value_or("error");
-			reply = std::move(output);
-			return true;
-		}
-		virtual bool Prettify(const ParseResultBase& parsedData, std::unique_ptr<StringResultBase>& reply) const
-		{
-			GetValueResult<T> const& parsedDataInput = dynamic_cast<GetValueResult<T> const&>(parsedData);
-			std::unique_ptr<StringResultUsingString>    output = std::make_unique<StringResultUsingString>();
+template <typename T> class GetValue : public TestAction {
 
-			output->result = glz::write < glz::opts{ .prettify = true } > (parsedDataInput.data).value_or("error");
-			reply = std::move(output);
-			return true;
-		}
-	};
+public:
+  virtual bool Parse(const char *json, size_t,
+                     std::unique_ptr<ParseResultBase> &reply) const {
+    std::unique_ptr<GetValueResult<T>> parsedData =
+        std::make_unique<GetValueResult<T>>();
+    auto error = glz::read<glz::opts{.validate_trailing_whitespace = true}>(
+        parsedData->data, json);
+    if (!error) {
+      reply = std::move(parsedData);
+    }
+    return true;
+  }
+  virtual bool Stringify(const ParseResultBase &parsedData,
+                         std::unique_ptr<StringResultBase> &reply) const {
+    GetValueResult<T> const &parsedDataInput =
+        dynamic_cast<GetValueResult<T> const &>(parsedData);
+    std::unique_ptr<StringResultUsingString> output =
+        std::make_unique<StringResultUsingString>();
 
-}
+    auto ec = glz::write_json(parsedDataInput.data, output->result);
+    if (not ec) {
+      reply = std::move(output);
+    }
+    return true;
+  }
+  virtual bool Prettify(const ParseResultBase &parsedData,
+                        std::unique_ptr<StringResultBase> &reply) const {
+    GetValueResult<T> const &parsedDataInput =
+        dynamic_cast<GetValueResult<T> const &>(parsedData);
+    std::unique_ptr<StringResultUsingString> output =
+        std::make_unique<StringResultUsingString>();
+
+    auto ec = glz::write<glz::opts{.prettify = true}>(parsedDataInput.data, output->result)
+    if (not ec) {
+      reply = std::move(output);
+    }
+    return true;
+  }
+};
+
+} // namespace Glaze
 #endif

--- a/src/ThirdParty/Glaze_Common.h
+++ b/src/ThirdParty/Glaze_Common.h
@@ -267,7 +267,7 @@ public:
     std::unique_ptr<StringResultUsingString> output =
         std::make_unique<StringResultUsingString>();
 
-    auto ec = glz::write<glz::opts{.prettify = true}>(parsedDataInput.data, output->result)
+    auto ec = glz::write<glz::opts{.prettify = true}>(parsedDataInput.data, output->result);
     if (not ec) {
       reply = std::move(output);
     }


### PR DESCRIPTION
I haven't been able to build your test code (so there may be a minor typo here). But, I've updated the Glaze code to have simpler meta registration and avoid potential string copies. RVO doesn't always apply when converting from the contents of an `expected` to its destination. This change avoids compilers potentially generating a copy of the output buffer. It is also simpler and cleaner.